### PR TITLE
fix: enable JUnit 4 test execution in Maven build

### DIFF
--- a/microservice-framework-common/pom.xml
+++ b/microservice-framework-common/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>6.1.13</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -37,10 +36,6 @@
         <dependency>
             <groupId>org.qubership.cloud</groupId>
             <artifactId>framework-extension-metrics</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.qubership.cloud</groupId>
-            <artifactId>framework-extension-springdoc-swagger</artifactId>
         </dependency>
         <dependency>
             <groupId>org.qubership.cloud</groupId>
@@ -100,6 +95,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
             <version>1.20.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microservice-framework-common/src/test/java/org/qubership/cloud/microserviceframework/TestApplication.java
+++ b/microservice-framework-common/src/test/java/org/qubership/cloud/microserviceframework/TestApplication.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.cloud.config.client.ConfigClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -19,7 +20,8 @@ import static org.mockito.Mockito.mock;
 @EnableAutoConfiguration(exclude = {
         ElasticsearchDataAutoConfiguration.class,
         ConfigClientAutoConfiguration.class,
-        MongoAutoConfiguration.class
+        MongoAutoConfiguration.class,
+        RestClientAutoConfiguration.class
 })
 public class TestApplication extends BaseApplicationCommon {
     @Bean

--- a/microservice-framework-parent/pom.xml
+++ b/microservice-framework-parent/pom.xml
@@ -17,7 +17,6 @@
         <mockito.version>5.14.2</mockito.version>
         <spring.security.version>6.4.1</spring.security.version>
         <spring.version>6.2.1</spring.version>
-        <spring.webmvc.version>6.1.13</spring.webmvc.version>
         <lombok.version>1.18.36</lombok.version>
         <jackson.version>2.18.2</jackson.version>
         <microservice.dependencies.version>11.0.1</microservice.dependencies.version>
@@ -80,7 +79,7 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-webmvc</artifactId>
-                <version>${spring.webmvc.version}</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -101,6 +100,17 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-expression</artifactId>
                 <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-jdbc</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>${spring.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.springdoc</groupId>

--- a/microservice-framework-resttemplate/pom.xml
+++ b/microservice-framework-resttemplate/pom.xml
@@ -100,7 +100,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/microservice-framework-webclient/pom.xml
+++ b/microservice-framework-webclient/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Add junit-vintage-engine dependency to support JUnit 4 tests
- Fix Spring Framework version conflicts
- Exclude RestClientAutoConfiguration for Spring Boot 3.3.4 compatibility