### PR TITLE
fix: exclude maven-build workflow from bulk release process

### DIFF
--- a/.github/workflow/maven-build.yaml
+++ b/.github/workflow/maven-build.yaml
@@ -1,0 +1,20 @@
+name: Maven build
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - 'v*'
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  mvn:
+    uses: netcracker/qubership-core-infra/.github/workflows/maven-build-with-sonar.yaml@v1.0.8
+    with:
+      event-name: ${{ github.event_name }}
+      actor: ${{ github.actor }}
+      sonar-project-key: ${{ vars.SONAR_PROJECT_KEY }}
+    secrets:
+      sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
fix: exclude maven-build workflow from bulk release process